### PR TITLE
Remove global namespace functions

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,10 @@
 <?php
   require_once("socrata.php");
 
+  function array_get($needle, $haystack) {
+    return (in_array($needle, array_keys($haystack)) ? $haystack[$needle] : NULL);
+  }
+
   $view_uid = "h8x4-nvyi";
   $root_url = "data.austintexas.gov";
   $app_token = "B0ixMbJj4LuQVfYnz95Hfp3Ni";

--- a/public/socrata.php
+++ b/public/socrata.php
@@ -169,13 +169,4 @@ class Socrata {
   }
 }
 
-
-// Convenience functions
-function array_get($needle, $haystack) {
-  return (in_array($needle, array_keys($haystack)) ? $haystack[$needle] : NULL);
-}
-
-function pre_dump($var) {
-  echo "<pre>" . print_r($var) . "</pre>";
-}
 ?>


### PR DESCRIPTION
It is generally recommended that you do not define functions in the global namespace when building a package that interoperates with others. Because this library does this with `array_get`, it is currently incompatible with Laravel (currently the [most widely used](https://dab1nmslvvntp.cloudfront.net/wp-content/uploads/2015/03/1427547421php_framework_popularity_at_work_-_sitepoint2c_2015.png) PHP framework).

This pull request removes the global namespace functions from the file that composer defines for inclusion. So that your `index.php` example still works, it adds `array_get` into that file specifically.